### PR TITLE
feat(auth): implement admin login with custom login page

### DIFF
--- a/backend/src/main/java/kr/co/programmers/cafe/domain/admin/AdminController.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/domain/admin/AdminController.java
@@ -19,11 +19,14 @@ public class AdminController {
     // 로그인 실패의 경우 error 를 로그인 페이지로 넘겨주기 위한 메서드
     @GetMapping("/login")
     public String adminLogin(@RequestParam(required = false) String error, Model model) {
+        log.info("로그인 페이지");
         if(error != null) {
-            model.addAttribute("errorMessage", "올바르지 않은 계정입니다!");
+            switch (error) {
+                case "ip_blocked" -> model.addAttribute("errorMessage", "외부 IP 에선 접속이 불가능합니다!");
+                case "login-failed" -> model.addAttribute("errorMessage", "올바르지 않은 계정입니다!");
+            }
             log.error("로그인 실패");
         }
-        log.info("로그인 페이지");
         return "admin/login-form";
     }
 

--- a/backend/src/main/java/kr/co/programmers/cafe/domain/admin/AdminController.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/domain/admin/AdminController.java
@@ -1,0 +1,36 @@
+package kr.co.programmers.cafe.domain.admin;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+
+    //    private final AdminService adminService;
+
+    // 로그인 실패의 경우 error 를 로그인 페이지로 넘겨주기 위한 메서드
+    @GetMapping("/login")
+    public String adminLogin(@RequestParam(required = false) String error, Model model) {
+        if(error != null) {
+            model.addAttribute("errorMessage", "올바르지 않은 계정입니다!");
+            log.error("로그인 실패");
+        }
+        log.info("로그인 페이지");
+        return "admin/login-form";
+    }
+
+    // 로그인 성공 테스트 용
+    @GetMapping("/manage")
+    public String adminManage() {
+        log.info("관리 페이지 호출 테스트 - 로그인 성공");
+        return "admin/manage-form";
+    }
+}

--- a/backend/src/main/java/kr/co/programmers/cafe/global/config/CustomUserDetailsService.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/global/config/CustomUserDetailsService.java
@@ -1,0 +1,47 @@
+package kr.co.programmers.cafe.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserDetails userDetails;
+
+    // yml 파일 기반 인증 정보를 담은 UserDetails 생성
+    public CustomUserDetailsService(@Value("${spring.security.user.name}") String username,
+                                    @Value("${spring.security.user.password}") String password,
+                                    @Value("${spring.security.user.roles}") String roles) {
+        log.info("roles = {}", roles);
+        this.userDetails = User.builder()
+                .username(username)
+                .password(new BCryptPasswordEncoder().encode(password))
+                .roles(roles)
+                .build();
+    }
+
+    // yml 파일 기반 인증 정보를 만들기 위해 Override
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        if (!userDetails.getUsername().equals(username)) {
+            throw new UsernameNotFoundException("사용자를 찾을 수 없습니다.");
+        }
+
+        boolean isAdmin = userDetails.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+
+        if (!isAdmin) {
+            log.warn("ADMIN 권한 부족");
+            throw new UsernameNotFoundException("권한이 부족합니다.");  // 로그인 실패 처리됨
+        }
+        log.info("Authorities = {}", userDetails.getAuthorities());
+        return userDetails;
+    }
+}

--- a/backend/src/main/java/kr/co/programmers/cafe/global/config/IpValidationFilter.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/global/config/IpValidationFilter.java
@@ -1,0 +1,33 @@
+package kr.co.programmers.cafe.global.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class IpValidationFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String ip = request.getRemoteAddr();
+        boolean isLocal = "127.0.0.1".equals(ip) || "0:0:0:0:0:0:0:1".equals(ip);
+
+        // 로그인 요청인 경우 IP 검증
+        if ("/admin/login".equals(request.getRequestURI())
+                && "POST".equalsIgnoreCase(request.getMethod())) {
+            if (!isLocal) {
+                response.sendRedirect("/admin/login?error=ip_blocked");
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/kr/co/programmers/cafe/global/config/SecurityConfig.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/global/config/SecurityConfig.java
@@ -1,0 +1,55 @@
+package kr.co.programmers.cafe.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/admin/**")
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/admin/login").permitAll()
+                        .requestMatchers("/admin/**").access((authentication, context) -> {
+                            var request = context.getRequest();
+                            var ip = request.getRemoteAddr();
+                            var isLocal = "127.0.0.1".equals(ip) || "0:0:0:0:0:0:0:1".equals(ip);
+                            var hasAdminRole = authentication.get().getAuthorities().stream()
+                                    .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+                            return new AuthorizationDecision(isLocal && hasAdminRole);
+                        })
+                )
+                .formLogin(form -> form
+                        .loginPage("/admin/login")
+                        .loginProcessingUrl("/admin/login")
+                        .defaultSuccessUrl("/admin/manage")
+                        .failureUrl("/admin/login?error")
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/admin/logout")
+                        .logoutSuccessUrl("/admin/login")
+                        .invalidateHttpSession(true)
+                        .clearAuthentication(true))
+                .csrf(csrf -> csrf
+                        .ignoringRequestMatchers("/api/**")
+                );
+        return http.build();
+    }
+}

--- a/backend/src/main/resources/application-ref.yml
+++ b/backend/src/main/resources/application-ref.yml
@@ -21,6 +21,13 @@ spring:
   profiles:
     active: prod
 
+  # 관리자 계정
+  security:
+    user:
+      name: example
+      password: example
+      roles: ADMIN
+
 ---
 # dev profile
 spring:

--- a/backend/src/main/resources/templates/admin/login-form.html
+++ b/backend/src/main/resources/templates/admin/login-form.html
@@ -1,0 +1,52 @@
+<!-- templates/admin/login-form.html -->
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>관리자 로그인</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    .error-border {
+      border-color: #dc3545 !important;
+    }
+    .error-message {
+      color: #dc3545;
+      font-size: 0.9em;
+      margin-top: 0.25rem;
+    }
+  </style>
+</head>
+<body class="bg-light">
+<div class="container mt-5">
+  <div class="row justify-content-center">
+    <div class="col-md-4">
+      <div class="card shadow rounded-3">
+        <div class="card-body">
+          <h4 class="card-title text-center mb-4">관리자 로그인</h4>
+          <form th:action="@{/admin/login}" method="post">
+            <div class="mb-3">
+              <label for="username" class="form-label">아이디</label>
+              <input type="text" name="username" id="username"
+                     th:classappend="${errorMessage} ? 'error-border' : ''"
+                     class="form-control"
+                     placeholder="아이디" required>
+            </div>
+            <div class="mb-3">
+              <label for="password" class="form-label">비밀번호</label>
+              <input type="password" name="password" id="password"
+                     th:classappend="${errorMessage} ? 'error-border' : ''"
+                     class="form-control"
+                     placeholder="비밀번호" required>
+              <div th:if="${errorMessage}" class="error-message" th:text="${errorMessage}"></div>
+            </div>
+            <div class="d-grid">
+              <button type="submit" class="btn btn-primary">로그인</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/manage-form.html
+++ b/backend/src/main/resources/templates/admin/manage-form.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>로그인 성공 테스트 페이지</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/backend/src/test/java/kr/co/programmers/cafe/SecurityTests.java
+++ b/backend/src/test/java/kr/co/programmers/cafe/SecurityTests.java
@@ -1,0 +1,85 @@
+package kr.co.programmers.cafe;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class SecurityTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private static final String ADMIN_USERNAME = "admin";
+    private static final String ADMIN_PASSWORD = "1234";
+
+    private static final String LOGIN_URL = "/admin/login";
+    private static final String MANAGE_URL = "/admin/manage";
+
+    // 내부 IP + ADMIN 권한 → 성공
+    @Test
+    void internalIpWithAdminRole_shouldSucceed() throws Exception {
+        mockMvc.perform(post(LOGIN_URL)
+                        .param("username", ADMIN_USERNAME)
+                        .param("password", ADMIN_PASSWORD)
+                        .with(csrf())
+                        .with(request -> {
+                            request.setRemoteAddr("127.0.0.1");
+                            return request;
+                        }))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(MANAGE_URL));
+    }
+
+    // 내부 IP + USER 권한 → 실패 (Spring Security 자체 로직 실패 → login?error 리다이렉트)
+    @Test
+    @WithMockUser(username = ADMIN_USERNAME, roles = "USER")
+    void internalIpWithUserRole_shouldFail() throws Exception {
+        mockMvc.perform(post(LOGIN_URL)
+                        .with(csrf())
+                        .with(request -> {
+                            request.setRemoteAddr("127.0.0.1");
+                            return request;
+                        }))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(LOGIN_URL + "?error=login_failed"));
+    }
+
+    // 외부 IP + USER 권한 → 실패
+    @Test
+    @WithMockUser(username = ADMIN_USERNAME, roles = "USER")
+    void externalIpWithUserRole_shouldFail() throws Exception {
+        mockMvc.perform(post(LOGIN_URL)
+                        .with(csrf())
+                        .with(request -> {
+                            request.setRemoteAddr("192.168.1.1");
+                            return request;
+                        }))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(LOGIN_URL + "?error=ip_blocked"));
+    }
+
+    // 외부 IP + ADMIN 권한 → 실패 (IP 차단으로 manage 접근 불가)
+    @Test
+    void externalIpWithAdminRole_shouldFail() throws Exception {
+        mockMvc.perform(post(LOGIN_URL)
+                        .param("username", ADMIN_USERNAME)
+                        .param("password", ADMIN_PASSWORD)
+                        .with(csrf())
+                        .with(request -> {
+                            request.setRemoteAddr("192.168.1.1");
+                            return request;
+                        }))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(LOGIN_URL + "?error=ip_blocked"));
+    }
+}


### PR DESCRIPTION
Developed initial admin login feature using Spring Security. Authentication is based on hardcoded admin information in the yml file, with a CustomUserDetails service implementing UserDetailsService. Added a custom Thymeleaf login page template for admins, and implemented AdminController to handle login failures by redirecting with error messages.

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
### 관리자 로그인 기능 구현
스프링 시큐리티로 yml 파일에 저장된 관리자 정보를 토대로 인증을 구현

### 관리자 로그인 페이지 구현
타임리프 템플릿을 통해 SSR 관리자 로그인 페이지 구현

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
### 관리자 로그인 기능

<details>
<summary><strong>시큐리티 기능 사용을 위한 Config 클래스 구현</strong></summary>

- /admin 요청에 대한 경로를 ADMIN 권한과 로컬 아이피의 경우에만 접근 가능하게 설정 (로그인 페이지에 한해 모두 허용)  
- 로그인 처리 url 설정 및 성공, 실패의 경우 리다이렉트 url 설정  
- 로그아웃 처리 url 설정 및 세션, 인증 정보를 초기화 설정  
- /api 요청의 경우 csrf 토큰 무시 설정  

</details>

<details>
<summary><strong>yml 파일로부터 인증 객체 생성을 위한 CustomUserDetailsService 클래스 구현</strong></summary>

- yml 파일의 관리자 정보를 통해 인증 객체 생성 후 권한 검사 구현  
- 현재 구현은 단일 관리자 (1명) 기준 구현  
- 여러 명의 관리자를 둔다면 리스트 방식 관리로 변경 필요  

</details>

<details>
<summary><strong>로그인 실패 시 에러 메시지 출력을 위한 GetMapping 메서드 구현 (AdminController)</strong></summary>

- 시큐리티 설정으로 로그인 실패 시 에러를 가지고 다시 로그인 화면으로 리다이렉트하게 설정  
- 에러를 가지고 리다이렉트된 경우 로그인 화면에 에러 메시지 출력 구현  

</details>

### 관리자 로그인 페이지 구현

<details>
<summary><strong>타임리프 템플릿을 사용한 로그인 페이지 구현</strong></summary>

- 타임리프 템플릿 엔진을 사용한 페이지 조회 구현
- 부트스트랩을 사용해 기본적인 디자인 구현 -> 디자인 관련 추후 협의 후 변경 예정
- form action 방식을 통해 로그인 post 요청
- 리다이렉트된 페이지에 에러 정보가 넘어온다면 입력 필드 테두리를 빨간색으로 변경 후 에러 메시지 출력

</details>

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
Q. 기본적인 권한에 관한 테스트는 진행해봤는데 로컬 아이피에서만 접속 가능한 지 테스트는 어떻게 해봐야 할지
