### PR TITLE
refactor: 주문 검색 성능 최적화

### DIFF
--- a/backend/src/main/java/kr/co/programmers/cafe/domain/order/app/OrderService.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/domain/order/app/OrderService.java
@@ -178,7 +178,7 @@ public class OrderService {
 //    }
     @Transactional
     public Optional<OrderResponse> searchOrder(Long orderId) {
-        Optional<Order> optionalOrder = orderRepository.findById(orderId);
+        Optional<Order> optionalOrder = orderRepository.searchById(orderId);
         return optionalOrder.map(
                 order -> OrderResponse.builder()
                         .orderId(order.getId())

--- a/backend/src/main/java/kr/co/programmers/cafe/domain/order/app/OrderService.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/domain/order/app/OrderService.java
@@ -113,7 +113,7 @@ public class OrderService {
 
     @Transactional
     public OrderResponse getOrderById(Long orderId) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.searchById(orderId)
                 .orElseThrow(() -> new RuntimeException("해당 주문을 찾을 수 없습니다. "));
 
         List<OrderItemResponse> orderItemResponses = order.getOrderItems().stream()
@@ -148,34 +148,9 @@ public class OrderService {
                 .zipCode(order.getZipCode())
                 .totalPrice(order.getTotalPrice())
                 .status(order.getStatus())
-                .orderItems(order.getOrderItems().stream()
-                        .map(orderItem -> OrderItemResponse.builder()
-                                .name(orderItem.getItem().getName())
-                                .price(orderItem.getItem().getPrice())
-                                .quantity(orderItem.getQuantity())
-                                .build())
-                        .collect(Collectors.toList()))
                 .build());
     }
 
-    // 목록 검색용
-//    @Transactional
-//    public Optional<OrderResponse> searchOrder(Long orderId) {
-//        return orderRepository.findById(orderId)
-//                .map(order -> OrderResponse.builder()
-//                        .orderId(order.getId())
-//                        .email(order.getEmail())
-//                        .address(order.getAddress())
-//                        .totalPrice(order.getTotalPrice())
-//                        .status(order.getStatus())
-//                        .orderItems(order.getOrderItems().stream()
-//                                .map(orderItem -> OrderItemResponse.builder()
-//                                        .name(orderItem.getItem().getName())
-//                                        .quantity(orderItem.getQuantity())
-//                                        .build())
-//                                .toList())
-//                        .build());
-//    }
     @Transactional
     public Optional<OrderResponse> searchOrder(Long orderId) {
         Optional<Order> optionalOrder = orderRepository.searchById(orderId);

--- a/backend/src/main/java/kr/co/programmers/cafe/domain/order/app/OrderService.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/domain/order/app/OrderService.java
@@ -158,23 +158,43 @@ public class OrderService {
                 .build());
     }
 
-    // 목록 단건 조회용
+    // 목록 검색용
+//    @Transactional
+//    public Optional<OrderResponse> searchOrder(Long orderId) {
+//        return orderRepository.findById(orderId)
+//                .map(order -> OrderResponse.builder()
+//                        .orderId(order.getId())
+//                        .email(order.getEmail())
+//                        .address(order.getAddress())
+//                        .totalPrice(order.getTotalPrice())
+//                        .status(order.getStatus())
+//                        .orderItems(order.getOrderItems().stream()
+//                                .map(orderItem -> OrderItemResponse.builder()
+//                                        .name(orderItem.getItem().getName())
+//                                        .quantity(orderItem.getQuantity())
+//                                        .build())
+//                                .toList())
+//                        .build());
+//    }
     @Transactional
     public Optional<OrderResponse> searchOrder(Long orderId) {
-        return orderRepository.findById(orderId)
-                .map(order -> OrderResponse.builder()
+        Optional<Order> optionalOrder = orderRepository.findById(orderId);
+        return optionalOrder.map(
+                order -> OrderResponse.builder()
                         .orderId(order.getId())
                         .email(order.getEmail())
                         .address(order.getAddress())
+                        .zipCode(order.getZipCode())
                         .totalPrice(order.getTotalPrice())
                         .status(order.getStatus())
-                        .orderItems(order.getOrderItems().stream()
-                                .map(orderItem -> OrderItemResponse.builder()
-                                        .name(orderItem.getItem().getName())
-                                        .quantity(orderItem.getQuantity())
-                                        .build())
-                                .toList())
-                        .build());
+                        .orderItems(order.getOrderItems().stream().map(
+                                        orderItem -> OrderItemResponse.builder()
+                                                .name(orderItem.getItem().getName())
+                                                .quantity(orderItem.getQuantity())
+                                                .build()
+                                ).toList()
+                        ).build()
+        );
     }
 
     @Transactional
@@ -186,4 +206,5 @@ public class OrderService {
 
 
 }
+
 

--- a/backend/src/main/java/kr/co/programmers/cafe/domain/order/app/OrderService.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/domain/order/app/OrderService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -113,7 +114,7 @@ public class OrderService {
 
     @Transactional
     public OrderResponse getOrderById(Long orderId) {
-        Order order = orderRepository.searchById(orderId)
+        Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new RuntimeException("해당 주문을 찾을 수 없습니다. "));
 
         List<OrderItemResponse> orderItemResponses = order.getOrderItems().stream()
@@ -153,7 +154,9 @@ public class OrderService {
 
     @Transactional
     public Optional<OrderResponse> searchOrder(Long orderId) {
-        Optional<Order> optionalOrder = orderRepository.searchById(orderId);
+        Optional<Order> optionalOrder = Optional.ofNullable(orderRepository.findById(orderId).orElseThrow(
+                () -> new NoSuchElementException(" 해당 주문을 찾을 수 없습니다.")
+        ));
         return optionalOrder.map(
                 order -> OrderResponse.builder()
                         .orderId(order.getId())

--- a/backend/src/main/java/kr/co/programmers/cafe/domain/order/dao/OrderRepository.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/domain/order/dao/OrderRepository.java
@@ -2,6 +2,17 @@ package kr.co.programmers.cafe.domain.order.dao;
 
 import kr.co.programmers.cafe.domain.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    @Query("select o from Order o " +
+            "join fetch o.orderItems oi " +
+            "join fetch oi.item " +
+            "where o.id = :orderId")
+    Optional<Order> searchById(@Param("orderId") Long id);
 }
+

--- a/backend/src/main/java/kr/co/programmers/cafe/domain/order/dao/OrderRepository.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/domain/order/dao/OrderRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     @EntityGraph(attributePaths = {"orderItems", "orderItems.item"})
-    Optional<Order> searchById(@Param("orderId") Long id);
+    Optional<Order> findById(Long id);
 }
 
 

--- a/backend/src/main/java/kr/co/programmers/cafe/domain/order/dao/OrderRepository.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/domain/order/dao/OrderRepository.java
@@ -3,7 +3,6 @@ package kr.co.programmers.cafe.domain.order.dao;
 import kr.co.programmers.cafe.domain.order.entity.Order;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;

--- a/backend/src/main/java/kr/co/programmers/cafe/domain/order/dao/OrderRepository.java
+++ b/backend/src/main/java/kr/co/programmers/cafe/domain/order/dao/OrderRepository.java
@@ -1,6 +1,7 @@
 package kr.co.programmers.cafe.domain.order.dao;
 
 import kr.co.programmers.cafe.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,10 +10,8 @@ import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    @Query("select o from Order o " +
-            "join fetch o.orderItems oi " +
-            "join fetch oi.item " +
-            "where o.id = :orderId")
+    @EntityGraph(attributePaths = {"orderItems", "orderItems.item"})
     Optional<Order> searchById(@Param("orderId") Long id);
 }
+
 

--- a/backend/src/main/resources/templates/orders/order-list.html
+++ b/backend/src/main/resources/templates/orders/order-list.html
@@ -80,7 +80,7 @@
     <form th:action="@{/admin/orders}" method="get" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
 
         <!-- 돌아가기 버튼 (왼쪽) -->
-        <a th:href="@{/admin}"
+        <a th:href="@{/admin/main}"
            style="padding: 8px 16px; background-color: #ccc; color: #333; border-radius: 5px; text-decoration: none; font-weight: bold;">
             돌아가기
         </a>


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
orderService의 searchOrder에서 Order엔티티에서 OrderItem엔티티까지 쿼리를 여러번 날려 검색하던 방식을 
fetch join으로 한번의 쿼리로 검색가능하도록 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
fetch join으로 OrderItem과 Item을 붙여서 OrderId로 한번만 조회