### PR TITLE
fix: 관리자 상품 수정 페이지 이미지 미표시 오류

### DIFF
--- a/backend/src/main/resources/templates/admin/items/item-edit.html
+++ b/backend/src/main/resources/templates/admin/items/item-edit.html
@@ -48,7 +48,9 @@
 
     <div class="form-field image-container" style="text-align: center;">
         <div class="form-field image-container" style="text-align: center;"
-             th:if="${item != null && item.image != null}" th:onerror="this.style.display='none'">
+             th:if="${itemEditForm != null && itemEditForm.imageUrl != null}" th:onerror="this.style.display='none'">
+            <img class="item-image"
+                 th:src="@{'/api/items/' + ${itemEditForm.id} + '/images'}" alt="상품 이미지">
         </div>
 
     <div class="button-container">


### PR DESCRIPTION
관리자 상품 수정폼에 기존 이미지가 표시되지 않는 문제를 해결했습니다.
Closes: #60 